### PR TITLE
Install required `make` package for chef_gem[ruby-augeas]

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,6 +1,6 @@
 case node['platform']
 when 'debian', 'ubuntu'
-  default['augeas']['packages'] = %w(libaugeas-dev ruby1.9.1-dev libxml2-dev pkg-config)
+  default['augeas']['packages'] = %w(make libaugeas-dev ruby1.9.1-dev libxml2-dev pkg-config)
 else
-  default['augeas']['packages'] = %w(augeas-devel)
+  default['augeas']['packages'] = %w(make augeas-devel)
 end


### PR DESCRIPTION
augeas::geminstall recipe fails when make package is missing on host.

Part of kitchen logs:

```
[2014-09-09T09:39:25+00:00] ERROR: chef_gem[ruby-augeas] (augeas::geminstall line 10) had an error: Mixlib::ShellOut::ShellCommandFailed: Expected process to exit with [0], but received '1'
       ---- Begin output of /opt/chef/embedded/bin/gem install ruby-augeas -q --no-rdoc --no-ri -v "0.5.0" ----
       STDOUT: Building native extensions.  This could take a while...
       STDERR: ERROR:  Error installing ruby-augeas:
        ERROR: Failed to build gem native extension.

        /opt/chef/embedded/bin/ruby extconf.rb
       creating Makefile

       make
       sh: 1: make: not found
```
